### PR TITLE
Slightly reduce font size, make it depend on width AND height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@
 
 html {
   font-family: Asap, sans-serif;
-  font-size: calc(1em + 0.5vw);
+  font-size: calc(1em + 0.2vw + 0.2vh);
   color: #111;
   line-height: 1.4;
 }


### PR DESCRIPTION
Instead of just considering the `vw` in the font size calculation, it takes into consideration `vw` and `vh`. This avoids that on landscape/widescreen setups the width of the browser window ends up having undue influence on the font size leading to an uncomfortable "letterboxing" effect.

Closes
https://github.com/ThePacielloGroup/inclusive-design-principles/issues/50